### PR TITLE
Standardise error codes via FFIEnum

### DIFF
--- a/hams/src/hams/webservice.rs
+++ b/hams/src/hams/webservice.rs
@@ -52,6 +52,10 @@ async fn handle_rejection(err: Rejection) -> std::result::Result<impl Reply, Inf
             HamsError::CStringToString(_) => todo!(),
             HamsError::TryFromIntError(_) => todo!(),
             HamsError::SystemTimeError(_) => todo!(),
+            HamsError::FFIError(_msg) => todo!(),
+            HamsError::Utf8Error(_) => todo!(),
+            HamsError::FFIErrorBufferNotBigEnough => todo!(),
+            HamsError::NotError(_) => todo!(),
             // Add match arms for the remaining error variants here
         }
     } else {


### PR DESCRIPTION
Use an enum to standardise return codes from FFI