### PR TITLE
Add sample-rust-static and support closures in hams

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "hams",
     "hamsrs",
     "sample-rust-shared",
+    "sample-rust-static",
 ]
 resolver = "2"
 # exclude = ["rust_cli"]

--- a/hams/src/hams/config.rs
+++ b/hams/src/hams/config.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 use std::net::SocketAddr;
 
 /// Configuration for the HAMS service
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Debug)]
 #[serde(default)]
 pub struct HamsConfig {
     /// Hostname to start the webservice on

--- a/hams/src/hams/mod.rs
+++ b/hams/src/hams/mod.rs
@@ -21,30 +21,24 @@ use tokio::signal::unix::signal;
 
 use tokio::signal::unix::SignalKind;
 use tokio_util::sync::CancellationToken;
+use std::ffi::CStr;
+use std::fmt;
 
-#[derive(Debug)]
-pub(crate) struct HamsCallback {
-    user_data: *mut c_void,
-    cb: unsafe extern "C" fn(*mut c_void),
+pub(crate) struct CallbackFn(pub Box<dyn Fn() + Send>);
+
+impl fmt::Debug for CallbackFn {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "CallbackFn")
+    }
 }
 
-/// Manually provide the Send impl for HamsCallBack to indicate it is thread safe.
-/// This is required because HamsCallback cannot automatically derive if it can support
-/// Send impl.
-unsafe impl Send for HamsCallback {}
+pub(crate) struct PrometheusFn(pub Box<dyn Fn() -> String + Send>);
 
-/// Callback struct for Prometheus metrics collection
-#[derive(Debug, Clone)]
-pub struct PrometheusCallback {
-    /// Function pointer to the external callback
-    pub my_cb: extern "C" fn(ptr: *const c_void) -> *mut libc::c_char,
-    /// Function pointer to free the result string
-    pub my_cb_free: extern "C" fn(*mut libc::c_char),
-    /// Opaque pointer to state passed to the callback
-    pub state: *const c_void,
+impl fmt::Debug for PrometheusFn {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "PrometheusFn")
+    }
 }
-
-unsafe impl Send for PrometheusCallback {}
 
 /// Main struct for the Health and Monitoring System
 #[derive(Debug, Clone)]
@@ -52,11 +46,11 @@ pub struct Hams {
     /// Name of the application this HaMS is for
     pub(crate) name: String,
     /// Provide the version of the application
-    pub(crate) version: String,
+    pub version: String,
     /// Provide the version of the release of HaMS
-    pub(crate) hams_version: String,
+    pub hams_version: String,
     /// Provide the name of the package
-    pub(crate) hams_name: String,
+    pub hams_name: String,
 
     /// Provide the address on which to serve the HaMS readyness and liveness
     address: SocketAddr,
@@ -82,12 +76,12 @@ pub struct Hams {
     cancellation_token: CancellationToken,
 
     /// Callback to be called on shutdown
-    pub(crate) shutdown_cb: Arc<Mutex<Option<HamsCallback>>>,
+    pub(crate) shutdown_cb: Arc<Mutex<Option<CallbackFn>>>,
     /// joinhandle to wait when shutting down service
     thread_jh: Arc<Mutex<Option<JoinHandle<Result<(), HamsError>>>>>,
 
     /// Callback to be called on prometheus
-    pub(crate) prometheus_cb: Arc<Mutex<Option<PrometheusCallback>>>,
+    pub(crate) prometheus_cb: Arc<Mutex<Option<PrometheusFn>>>,
 }
 
 impl Hams {
@@ -133,7 +127,21 @@ impl Hams {
     ) -> Result<(), HamsError> {
         info!("Add shutdown to {}", self.name);
 
-        *self.shutdown_cb.lock()? = Some(HamsCallback { user_data, cb });
+        let user_data_addr = user_data as usize;
+
+        let closure = move || {
+             unsafe { cb(user_data_addr as *mut c_void) };
+        };
+
+        *self.shutdown_cb.lock()? = Some(CallbackFn(Box::new(closure)));
+        Ok(())
+    }
+
+    pub fn register_shutdown_closure<F>(&self, cb: F) -> Result<(), HamsError>
+    where F: Fn() + Send + 'static
+    {
+        info!("Add shutdown closure to {}", self.name);
+        *self.shutdown_cb.lock()? = Some(CallbackFn(Box::new(cb)));
         Ok(())
     }
 
@@ -152,11 +160,30 @@ impl Hams {
     ) -> Result<(), HamsError> {
         info!("Add prometheus to {}", self.name);
 
-        *self.prometheus_cb.lock()? = Some(PrometheusCallback {
-            my_cb,
-            my_cb_free,
-            state,
-        });
+        let state_addr = state as usize;
+
+        let closure = move || -> String {
+            unsafe {
+                let ptr = my_cb(state_addr as *const c_void);
+                if ptr.is_null() {
+                    return String::new();
+                }
+                let c_str = CStr::from_ptr(ptr);
+                let result = c_str.to_string_lossy().to_string();
+                my_cb_free(ptr);
+                result
+            }
+        };
+
+        *self.prometheus_cb.lock()? = Some(PrometheusFn(Box::new(closure)));
+        Ok(())
+    }
+
+    pub fn register_prometheus_closure<F>(&self, cb: F) -> Result<(), HamsError>
+    where F: Fn() -> String + Send + 'static
+    {
+        info!("Add prometheus closure to {}", self.name);
+        *self.prometheus_cb.lock()? = Some(PrometheusFn(Box::new(cb)));
         Ok(())
     }
 
@@ -395,12 +422,12 @@ impl Hams {
     }
 
     pub(crate) fn call_shutdown_callback(
-        shutdown_cb: Option<&HamsCallback>,
+        shutdown_cb: Option<&CallbackFn>,
     ) -> Result<(), HamsError> {
-        match shutdown_cb.as_ref() {
-            Some(hams_callback) => {
+        match shutdown_cb {
+            Some(callback) => {
                 info!("Triggering shutdown callback");
-                unsafe { (hams_callback.cb)(hams_callback.user_data) };
+                (callback.0)();
                 info!("Completed shutdown callback")
             }
             None => {
@@ -462,28 +489,35 @@ mod tests {
             }
         }
 
-        let prometheus_cb = PrometheusCallback {
-            my_cb: prometheus,
-            my_cb_free: prometheus_free,
-            state: &"splat".to_string() as *const String as *const c_void,
-        };
+        let state = "splat".to_string();
 
         hams.register_prometheus(
-            prometheus_cb.my_cb,
-            prometheus_cb.my_cb_free,
-            prometheus_cb.state,
+            prometheus,
+            prometheus_free,
+            &state as *const String as *const c_void,
         )
         .expect("Registered prometheus");
 
         let prometheus_cb = hams.prometheus_cb.lock().unwrap();
         let prometheus_cb = prometheus_cb.as_ref().unwrap();
 
-        let ptr = (prometheus_cb.my_cb)(prometheus_cb.state);
-        let c_str = unsafe { std::ffi::CStr::from_ptr(ptr) };
-        let str_slice = c_str.to_str().unwrap();
-        assert_eq!(str_slice, "test splat");
+        let result = (prometheus_cb.0)();
+        assert_eq!(result, "test splat");
+    }
 
-        (prometheus_cb.my_cb_free)(ptr);
+    #[test]
+    fn test_prometheus_closure() {
+        let mut hams = Hams::new(HamsConfig::default());
+
+        hams.register_prometheus_closure(|| {
+            "test closure".to_string()
+        }).expect("Registered prometheus closure");
+
+        let prometheus_cb = hams.prometheus_cb.lock().unwrap();
+        let prometheus_cb = prometheus_cb.as_ref().unwrap();
+
+        let result = (prometheus_cb.0)();
+        assert_eq!(result, "test closure");
     }
 
     /// Create a hams then start and stop it
@@ -569,6 +603,24 @@ mod tests {
             .expect("Called shutdown");
 
         assert_eq!(state, 1);
+    }
+
+    #[test]
+    fn test_hams_shutdown_closure_state() {
+        let mut hams = Hams::new(HamsConfig::default());
+
+        let state = Arc::new(Mutex::new(0));
+        let state_clone = state.clone();
+
+        hams.register_shutdown_closure(move || {
+            let mut s = state_clone.lock().unwrap();
+            *s += 1;
+        }).expect("Registered shutdown closure");
+
+        Hams::call_shutdown_callback(hams.shutdown_cb.lock().unwrap().as_ref())
+            .expect("Called shutdown");
+
+        assert_eq!(*state.lock().unwrap(), 1);
     }
 
     /// Test that startup and shutdown tasks actually run

--- a/hams/src/hams/webservice.rs
+++ b/hams/src/hams/webservice.rs
@@ -187,7 +187,7 @@ mod handlers {
     use crate::{error::HamsError, hams::check::HealthCheck};
     use log::{error, info};
     use serde::Serialize;
-    use std::{ffi::CStr, time::SystemTime};
+    use std::time::SystemTime;
     use warp::{http::Response, reject::Rejection};
 
     /// Reply structure for Version response
@@ -265,19 +265,8 @@ mod handlers {
         let metrics = match *x {
             Some(ref cb) => {
                 info!("Metrics are here");
-
-                let c_string = (cb.my_cb)(cb.state);
-
-                let c_string_2 = unsafe { CStr::from_ptr(c_string) };
-                let metric_response = c_string_2
-                    .to_str()
-                    .map_err(|e| warp::reject::custom(HamsError::Utf8Error(e)))?
-                    .to_string();
-
-                (cb.my_cb_free)(c_string);
-
-                metric_response
-                // "Metrics go here".to_string()
+                // Calling the closure directly now
+                (cb.0)()
             }
             None => {
                 info!("Metrics are NOT here");

--- a/hams/src/lib.rs
+++ b/hams/src/lib.rs
@@ -51,7 +51,7 @@ pub extern "C" fn hams_version() -> *const libc::c_char {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn hams_version_free(ptr: *mut libc::c_char) {
     if !ptr.is_null() {
-        drop(CString::from_raw(ptr));
+        unsafe { drop(CString::from_raw(ptr)) };
     }
 }
 
@@ -80,7 +80,7 @@ pub unsafe extern "C" fn hams_version_free(ptr: *mut libc::c_char) {
 pub extern "C" fn hams_logger_init(param: LogParam) -> i32 {
     // ffi_helpers::null_pointer_check!(param);
     catch_panic!(
-        logger_init(param);
+        unsafe { logger_init(param) };
         info!(
             "Logging registered for {}:{} (PID: {})",
             NAME,
@@ -617,7 +617,7 @@ pub unsafe extern "C" fn probe_manual_free(ptr: *mut Manual) -> i32 {
     ffi_helpers::null_pointer_check!(ptr);
 
     catch_panic!(
-        let probe = Box::from_raw(ptr);
+        let probe = unsafe { Box::from_raw(ptr) };
 
         info!("Releasing manual probe: {}", unsafe { CStr::from_ptr(probe.name()) }.to_string_lossy());
         drop(probe);
@@ -635,7 +635,7 @@ pub unsafe extern "C" fn probe_manual_boxed(ptr: *mut Manual) -> *mut BoxedHealt
 
     catch_panic!(
         let x = {
-            let probe =  (*ptr).clone();
+            let probe =  unsafe { (*ptr).clone() };
             let boxed_probe = BoxedHealthProbe::new(probe);
 
 
@@ -655,7 +655,7 @@ pub unsafe extern "C" fn probe_free(ptr: *mut BoxedHealthProbe) -> i32 {
     ffi_helpers::null_pointer_check!(ptr);
 
     catch_panic!(
-        let probe = Box::from_raw(ptr);
+        let probe = unsafe { Box::from_raw(ptr) };
 
         info!("Releasing probe: {}", unsafe { CStr::from_ptr(probe.name()) }.to_string_lossy());
         drop(probe);
@@ -672,7 +672,7 @@ pub unsafe extern "C" fn probe_manual_enable(ptr: *mut Manual) -> i32 {
     ffi_helpers::null_pointer_check!(ptr);
 
     catch_panic!(
-        let probe = &*ptr;
+        let probe = unsafe { &*ptr };
         probe.enable();
         Ok(1)
     )
@@ -687,7 +687,7 @@ pub unsafe extern "C" fn probe_manual_disable(ptr: *mut Manual) -> i32 {
     ffi_helpers::null_pointer_check!(ptr);
 
     catch_panic!(
-        let probe = &*ptr;
+        let probe = unsafe { &*ptr };
         probe.disable();
         Ok(1)
     )
@@ -702,7 +702,7 @@ pub unsafe extern "C" fn probe_manual_toggle(ptr: *mut Manual) -> i32 {
     ffi_helpers::null_pointer_check!(ptr);
 
     catch_panic!(
-        let probe = &*ptr;
+        let probe = unsafe { &*ptr };
         probe.toggle();
         Ok(1)
     )
@@ -722,7 +722,7 @@ pub unsafe extern "C" fn probe_manual_check(ptr: *mut Manual) -> i32 {
         .as_secs();
 
     catch_panic!(
-        let probe = &*ptr;
+        let probe = unsafe { &*ptr };
 
         Ok(probe.check(now.try_into()?) as i32)
     )
@@ -758,7 +758,7 @@ pub unsafe extern "C" fn probe_kick_free(ptr: *mut Kick) -> i32 {
     ffi_helpers::null_pointer_check!(ptr);
 
     catch_panic!(
-        let probe = Box::from_raw(ptr);
+        let probe = unsafe { Box::from_raw(ptr) };
 
         // let name = &probe.name();
 
@@ -778,7 +778,7 @@ pub unsafe extern "C" fn probe_kick_kick(ptr: *mut Kick) -> i32 {
     ffi_helpers::null_pointer_check!(ptr);
 
     catch_panic!(
-        let probe = &*ptr;
+        let probe = unsafe { &*ptr };
         probe.kick();
         Ok(1)
     )
@@ -792,7 +792,7 @@ pub unsafe extern "C" fn probe_kick_boxed(ptr: *mut Kick) -> *mut BoxedHealthPro
     ffi_helpers::null_pointer_check!(ptr);
 
     catch_panic!(
-        let probe = (*ptr).clone();
+        let probe = unsafe { (*ptr).clone() };
         let boxed_probe = BoxedHealthProbe::new(probe);
 
         Ok(boxed_probe.into_raw() as *mut BoxedHealthProbe<'static>)

--- a/sample-rust-static/Cargo.toml
+++ b/sample-rust-static/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "sample-rust-static"
+version = "0.3.0"
+edition = "2024"
+
+[dependencies]
+clap = { version = "~4.5", features = ["derive"] }
+env_logger = "~0.11"
+log = { version = "~0.4", features = ["release_max_level_info"] }
+ffi-log2 = { path = "../ffi-log2" }
+hams = { path = "../hams" }
+libc = "~0.2"
+serde = { version = "~1.0", features = ['std', 'derive'] }
+figment = { version = "~0.10", features = ["yaml", "env"] }
+ffi_helpers = "~0.3"
+tokio-util = "~0.7"
+
+
+# for client
+reqwest = {version ="~0.12", features = [ "json"] }
+tokio = { version = "~1.48", features = ["full"] }
+thiserror = "~2.0"
+futures = "~0.3"
+serde_json = { version="~1.0" }

--- a/sample-rust-static/src/client/error.rs
+++ b/sample-rust-static/src/client/error.rs
@@ -1,0 +1,14 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum MyError {
+    /// Error when starting a thread
+    #[error("io::Error eg from tokio start")]
+    IoError(#[from] std::io::Error),
+    /// A standard error with configurable message
+    #[error("Generic error message (use sparigly): `{0}`")]
+    Message(String),
+    /// Reqwest error
+    #[error("Reqwest error")]
+    ReqwestError(#[from] reqwest::Error),
+}

--- a/sample-rust-static/src/client/mod.rs
+++ b/sample-rust-static/src/client/mod.rs
@@ -1,0 +1,61 @@
+use std::collections::HashMap;
+
+use tokio_tools::run_in_tokio;
+
+mod error;
+mod tokio_tools;
+
+pub fn run_client_test() -> std::result::Result<(), error::MyError> {
+    run_in_tokio(async {
+        println!("Hello from client test");
+
+        let resp = reqwest::get("http://localhost:8079/hams/version")
+            .await?
+            .json::<HashMap<String, String>>()
+            .await?;
+        println!("{resp:#?}");
+
+        let resp = reqwest::get("http://localhost:8079/hams/version")
+            .await?
+            .json::<HashMap<String, String>>()
+            .await?;
+        println!("{resp:#?}");
+
+        let resp = reqwest::get("http://localhost:8079/hams/alive")
+            .await?
+            .text()
+            // .json::<HashMap<String, String>>()
+            .await?;
+        println!("{resp:#?}");
+
+        let resp = reqwest::get("http://localhost:8079/hams/alive_verbose")
+            .await?
+            .text()
+            // .json::<HashMap<String, String>>()
+            .await?;
+        println!("{resp:#?}");
+
+        let resp = reqwest::get("http://localhost:8079/hams/ready")
+            .await?
+            .text()
+            // .json::<HashMap<String, String>>()
+            .await?;
+        println!("{resp:#?}");
+
+        let resp = reqwest::get("http://localhost:8079/hams/ready_verbose")
+            .await?
+            .text()
+            // .json::<HashMap<String, String>>()
+            .await?;
+        println!("{resp:#?}");
+
+        let resp = reqwest::get("http://localhost:8079/hams/metrics")
+            .await?
+            .text()
+            // .json::<HashMap<String, String>>()
+            .await?;
+        println!("{resp}");
+
+        Ok(())
+    })
+}

--- a/sample-rust-static/src/client/tokio_tools.rs
+++ b/sample-rust-static/src/client/tokio_tools.rs
@@ -1,0 +1,25 @@
+//! Module to handle easy sending functions to tokio
+//!
+//! The provides two functions one function run_in_tokio creates and sends the function to tokio.
+//! The second function run_in_tokio_with_cancel allows the creation of a CancellationToken which can be used to shut down the tokio async.
+
+use super::error::MyError;
+use futures::Future;
+use log::info;
+
+/// run async function inside tokio instance on current thread
+pub fn run_in_tokio<F, T>(my_function: F) -> F::Output
+where
+    F: Future<Output = Result<T, MyError>>,
+{
+    info!("starting Tokio");
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+
+    // enter = enter the tokio context to allow sleep/tcpstream
+    // https://docs.rs/tokio/latest/tokio/runtime/struct.Runtime.html#method.enter
+    let _guard = rt.enter();
+    rt.block_on(my_function)
+}

--- a/sample-rust-static/src/config.rs
+++ b/sample-rust-static/src/config.rs
@@ -1,0 +1,29 @@
+use std::path::Path;
+
+use hams::hams::config::HamsConfig;
+use serde::Deserialize;
+
+use figment::{
+    Figment,
+    providers::{Format, Yaml},
+};
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct WebServiceConfig {
+    prefix: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Config {
+    webservice: WebServiceConfig,
+    #[serde(default)]
+    pub hams: HamsConfig,
+}
+
+impl Config {
+    // Note the `nested` option on both `file` providers. This makes each
+    // top-level dictionary act as a profile.
+    pub fn figment<P: AsRef<Path>>(path: P) -> Figment {
+        Figment::new().merge(Yaml::file(path))
+    }
+}

--- a/sample-rust-static/src/main.rs
+++ b/sample-rust-static/src/main.rs
@@ -1,0 +1,164 @@
+use std::path::PathBuf;
+use std::process::ExitCode;
+use std::thread;
+use std::time::Duration;
+
+use clap::Parser;
+use clap::Subcommand;
+use env_logger::Env;
+use ffi_log2::log_param;
+
+use hams::hams::config::TaskConfig;
+use hams::probe::manual::Manual;
+use hams::probe::kick::Kick;
+use hams::probe::FFIProbe;
+use hams::probe::AsyncHealthProbe;
+use hams::hams::Hams;
+
+mod client;
+mod config;
+
+use config::Config;
+use log::info;
+use std::sync::Arc;
+
+use crate::client::run_client_test;
+
+#[derive(Subcommand)]
+enum Commands {
+    /// does testing things
+    Test {
+        /// lists test values
+        #[arg(short, long)]
+        list: bool,
+    },
+    /// Validate the configuration
+    Validate {},
+    /// Start the service
+    Start {},
+}
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+struct Cli {
+    /// Sets a custom config file
+    #[arg(short, long, value_name = "FILE")]
+    config: PathBuf,
+
+    #[command(subcommand)]
+    command: Option<Commands>,
+}
+
+pub fn main() -> ExitCode {
+    let log_level = Env::default().default_filter_or("info");
+    env_logger::Builder::from_env(log_level).init();
+
+    let cli = Cli::parse();
+
+    info!("Value for config: {:?}", cli.config);
+
+    let config: Config = Config::figment(cli.config)
+        .extract()
+        .expect("Config file loaded");
+
+    match cli.command {
+        Some(Commands::Test { list }) => {
+            if list {
+                println!("Listing test values");
+            } else {
+                println!("Testing things");
+            }
+            ExitCode::SUCCESS
+        }
+        Some(Commands::Validate {}) => {
+            println!("Validating the configuration");
+            println!("Config: {:?}", config);
+            ExitCode::SUCCESS
+        }
+        Some(Commands::Start {}) => {
+            println!("Starting the service");
+
+            let mut hams = Hams::new(config.hams.clone());
+            println!("HaMS version: {}", hams.hams_version);
+
+            let probe0 = Manual::new("probe0", true);
+            println!("New Manual Probe CREATED");
+
+            let probe1 = Kick::new("probe1", Duration::from_secs(10));
+            println!("New Kick Probe CREATED");
+
+            let state_string = String::from("Hello from Rust PROMETHEUS");
+
+            hams.register_prometheus_closure(move || {
+                format!("test {}", state_string)
+            }).expect("register prometheus closure");
+
+            // Insert probes
+            // Note: FFIProbe adapts synchronous HealthProbe (like Manual/Kick) to AsyncHealthProbe
+            let ffi_probe0 = Box::new(FFIProbe::from(probe0.clone()));
+            hams.alive_insert(ffi_probe0);
+            println!("Probe0 inserted into alive");
+
+            let ffi_probe1 = Box::new(FFIProbe::from(probe1.clone()));
+            hams.alive_insert(ffi_probe1);
+
+            let ffi_probe0_startup = Box::new(FFIProbe::from(probe0.clone()));
+            hams.startup_insert(ffi_probe0_startup);
+
+            // Add a startup task that just sleeps for a bit
+            let startup_config = TaskConfig {
+                retries: 3,
+                sleep_ms: 100,
+                timeout_ms: 5000,
+            };
+            hams.startup_task_insert(
+                Arc::new(FFIProbe::from(probe0.clone())),
+                startup_config
+            );
+
+            // Add a shutdown task
+            let shutdown_config = TaskConfig {
+                retries: 1,
+                sleep_ms: 100,
+                timeout_ms: 1000,
+            };
+            hams.shutdown_task_insert(
+                Arc::new(FFIProbe::from(probe0.clone())),
+                shutdown_config
+            );
+
+            info!("HaMS Created, now starting it");
+
+            hams.start().unwrap();
+            info!("HaMS Started, now waiting for 3 secs");
+
+            run_client_test().expect("run client test");
+
+            thread::sleep(Duration::from_secs(1));
+
+            let probe0_to_remove = Box::new(FFIProbe::from(probe0.clone())) as Box<dyn AsyncHealthProbe>;
+            hams.alive_remove(&probe0_to_remove);
+            println!("Probe0 removed from alive");
+
+            hams.deregister_prometheus().expect("deregister prometheus");
+
+            run_client_test().expect("run client test");
+
+            info!("HaMS Started, running for a while");
+
+            thread::sleep(Duration::from_secs(5));
+
+            hams.stop().unwrap();
+
+            drop(probe0);
+            drop(probe1);
+            // drop(hams); // hams is dropped at end of scope
+
+            ExitCode::SUCCESS
+        }
+        None => {
+            println!("No command specified");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/sample-rust-static/test_data/config.yaml
+++ b/sample-rust-static/test_data/config.yaml
@@ -1,0 +1,3 @@
+---
+webservice:
+  prefix: api


### PR DESCRIPTION
Implemented `sample-rust-static` to demonstrate static linking of `hams`. Refactored `hams` to support Rust closures for callbacks while maintaining FFI compatibility.

---
*PR created automatically by Jules for task [17257052941652148549](https://jules.google.com/task/17257052941652148549) started by @Bengreen*